### PR TITLE
spring cleaning

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -171,7 +171,6 @@
 
               # lsp / formatting
               trouble-nvim # shows diagnostics in a menu
-              lsp_lines-nvim # shows LSP diagnostics in virtual text under the line
               nvim-lspconfig # configures language servers with sane defaults
               conform-nvim # polyglot formatting swiss army knife
 

--- a/init.lua
+++ b/init.lua
@@ -83,9 +83,7 @@ vim.api.nvim_create_autocmd("TextYankPost", {
 })
 
 -- silence the hover 'no information available' notification
-vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, {
-  silent = true,
-})
+vim.lsp.handlers["textDocument/hover"] = vim.lsp.buf.hover({ silent = true })
 
 vim.api.nvim_create_autocmd({ "VimResized" }, {
   group = vim.api.nvim_create_augroup("EqualizeSplits", {}),

--- a/init.lua
+++ b/init.lua
@@ -94,3 +94,15 @@ vim.api.nvim_create_autocmd({ "VimResized" }, {
   end,
   desc = "Resize splits with terminal window",
 })
+
+vim.diagnostic.config({
+  signs = {
+    text = {
+      [vim.diagnostic.severity.ERROR] = "󰅙",
+      [vim.diagnostic.severity.INFO] = "󰋼",
+      [vim.diagnostic.severity.HINT] = "󰌵",
+      [vim.diagnostic.severity.WARN] = "",
+    },
+  },
+  virtual_lines = { current_line = true },
+})

--- a/init.lua
+++ b/init.lua
@@ -78,7 +78,7 @@ vim.api.nvim_create_autocmd({
 -- flash yanked test
 vim.api.nvim_create_autocmd("TextYankPost", {
   callback = function()
-    vim.highlight.on_yank({ higroup = "Visual", timeout = 300 })
+    vim.hl.on_yank({ higroup = "Visual", timeout = 300 })
   end,
 })
 

--- a/lua/keymaps.lua
+++ b/lua/keymaps.lua
@@ -31,3 +31,7 @@ vim.keymap.set("v", "g<C-x>", "g<C-x>gv")
 vim.keymap.set("n", "<leader>cr", vim.lsp.buf.rename)
 
 vim.keymap.set("i", "<Tab>", require("scripts.intellitab").indent)
+
+vim.keymap.set({ "n", "i", "v" }, "<C-c>", function()
+  vim.diagnostic.config({ virtual_lines = { current_line = not vim.diagnostic.config().virtual_lines.current_line } })
+end, { desc = "toggle diagnostics on all lines" })

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -1,17 +1,6 @@
 local M = {}
 
 M.setup = function()
-  vim.diagnostic.config({
-    signs = {
-      text = {
-        [vim.diagnostic.severity.ERROR] = "󰅙",
-        [vim.diagnostic.severity.INFO] = "󰋼",
-        [vim.diagnostic.severity.HINT] = "󰌵",
-        [vim.diagnostic.severity.WARN] = "",
-      },
-    },
-  })
-
   local lspconfig = require("lspconfig")
 
   lspconfig.lua_ls.setup({

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -1,12 +1,16 @@
 local M = {}
 
 M.setup = function()
-  local symbols = { Error = "󰅙", Info = "󰋼", Hint = "󰌵", Warn = "" }
-
-  for name, icon in pairs(symbols) do
-    local hl = "DiagnosticSign" .. name
-    vim.fn.sign_define(hl, { text = icon, numhl = hl, texthl = hl })
-  end
+  vim.diagnostic.config({
+    signs = {
+      text = {
+        [vim.diagnostic.severity.ERROR] = "󰅙",
+        [vim.diagnostic.severity.INFO] = "󰋼",
+        [vim.diagnostic.severity.HINT] = "󰌵",
+        [vim.diagnostic.severity.WARN] = "",
+      },
+    },
+  })
 
   local lspconfig = require("lspconfig")
 

--- a/lua/plugins/blink-cmp.lua
+++ b/lua/plugins/blink-cmp.lua
@@ -48,9 +48,6 @@ return {
         providers = {
           lazydev = { module = "lazydev.integrations.blink", name = "LazyDev", score_offset = 100 },
           markdown = { module = "render-markdown.integ.blink", name = "RenderMarkdown" },
-          obsidian = { module = "blink.compat.source", name = "obsidian" },
-          obsidian_new = { module = "blink.compat.source", name = "obsidian_new" },
-          obsidian_tags = { module = "blink.compat.source", name = "obsidian_tags" },
           ripgrep = { module = "blink-ripgrep", name = "Ripgrep" },
         },
       },

--- a/lua/plugins/blink-cmp.lua
+++ b/lua/plugins/blink-cmp.lua
@@ -27,7 +27,11 @@ return {
       },
       fuzzy = { prebuilt_binaries = { download = false } },
       keymap = {
-        ["<C-g>"] = { _2_ },
+        ["<C-g>"] = {
+          function()
+            require("blink-cmp").show({ providers = { "ripgrep" } })
+          end,
+        },
         ["<C-j>"] = { "snippet_backward", "fallback" },
         ["<C-k>"] = { "snippet_forward", "fallback" },
         ["<S-Tab>"] = {},

--- a/lua/plugins/lz-spec.lua
+++ b/lua/plugins/lz-spec.lua
@@ -215,17 +215,6 @@ return {
     end,
   },
   {
-    "lsp_lines.nvim",
-    event = "LspAttach",
-    after = function()
-      require("lsp_lines").setup()
-      vim.diagnostic.config({
-        virtual_text = false,
-        virtual_lines = { only_current_line = true },
-      })
-    end,
-  },
-  {
     "tailwind-tools.nvim",
     after = function()
       local lz = require("lz.n")

--- a/lua/plugins/obsidian.lua
+++ b/lua/plugins/obsidian.lua
@@ -39,7 +39,8 @@ return {
       local opts = {
         ui = { enable = false },
         workspaces = workspaces,
-        completion = { nvim_cmp = false },
+        completion = { nvim_cmp = false, blink = true },
+        legacy_commands = false,
       }
       require("obsidian").setup(opts)
     end


### PR DESCRIPTION
- **chore: replace deprecated vim.lsp.with()**
- **fix(deprecation): new way to define diagnostic signs**
- **feat(deprecate): rework lsp diagnostic configuration**
- **fix: blink ripgrep unintentionally broken**
- **chore: chase new obsidian.nvim options**
- **chore(deprecate): vim.highlight -> vim.hl**
